### PR TITLE
Fix Kubecost Cost Analyzer pod readiness issue in kc_installer script

### DIFF
--- a/src/installer/kc-installer.sh
+++ b/src/installer/kc-installer.sh
@@ -41,9 +41,9 @@ kc_installer() {
             exit 1
         fi
 
-        # Wait for Kubecost Prometheus server pod to be ready
-        if ! kubectl -n "${KC_NAMESPACE[@]}" wait pod --for=condition=Ready -l component=server --timeout=1h &>/dev/null; then
-            log "${RED}[ERROR]" "[INSTALLER]" "Failed to wait for Kubecost Prometheus server pod to be ready. Exiting.${CC}"
+        # Wait for Kubecost Prometheus server and cost analyzer pod to be ready
+        if ! kubectl -n "${KC_NAMESPACE[@]}" wait pod --for=condition=Ready -l component=server -l app=cost-analyzer --timeout=1h &>/dev/null; then
+            log "${RED}[ERROR]" "[INSTALLER]" "Failed to wait for Kubecost pods to be ready. Exiting.${CC}"
             exit 1
         fi
 


### PR DESCRIPTION
# XkOps

## Issue
https://github.com/XgridInc/xkops/issues/17
## Description

The kc_installer script has been modified to wait for the Kubecost cost analyzer pod to become ready before running the kubectl cost command. This change was made because the test script that verifies the installation of Kubecost was failing due to the pod and service of the cost analyzer not being in the ready state. The kubectl cost command relies on the cost analyzer service to retrieve cost data, so waiting for the pod to be ready ensures that the command can run successfully.


## Checklist

- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes (if applicable)
- [x] Every function, interface, class has a comment describing what it does and input/output parameters
