### PR TITLE
Resolved Issue #29: Updated cleaner.sh to delete objects created in AWS & delete deployment before clearing namespaces

### DIFF
--- a/secret-manager/cleaner.sh
+++ b/secret-manager/cleaner.sh
@@ -91,6 +91,21 @@ else
   exit 1
 fi
 
+response=$(kubectl delete sa/xkops-secret-sa --namespace xkops 2>&1)
+# possible responses:
+# serviceaccount "xkops-secret-sa" deleted
+# Error from server (NotFound): serviceaccounts "xkops-secret-sa" not found
+
+if [[ $response == *"deleted"* ]]; then
+  echo "Successfully deleted xkops-secret-sa service account from the cluster."
+elif [[ $response == *"Error from server (NotFound)"*  ]]; then
+  echo "xkops-secret-sa service account has already been removed from the cluster."
+else
+  echo "$response"
+  echo "Failed to remove xkops-secret-sa service account from the cluster. Exiting..."
+  exit 1
+fi
+
 response=$(kubectl delete namespace xkops 2>&1)
 # possible responses:
 # namespace "xkops" deleted
@@ -103,6 +118,36 @@ elif [[ $response == *'Error from server (NotFound): namespaces'* ]]; then
 else
   echo "$response"
   echo "Failed to remove xkops namespace from your cluster. Exiting..."
+  exit 1
+fi
+
+response=$(kubectl delete deployment robusta-forwarder -n robusta 2>&1)
+# possible responses:
+# deployment.apps "robusta-forwarder" deleted
+# Error from server (NotFound): deployments.apps "robusta-forwarder" not found
+
+if [[ $response == *"deleted"* ]]; then
+  echo "Successfully removed robusta-forwarder deployment from your cluster."
+elif [[ $response == *'Error from server (NotFound): deployments.apps'* ]]; then
+  echo "robusta-forwarder deployment has already been removed from your cluster."
+else
+  echo "$response"
+  echo "Failed to remove robusta-forwarder deployment from your cluster. Exiting..."
+  exit 1
+fi
+
+response=$(kubectl delete deployment robusta-runner -n robusta 2>&1)
+# possible responses:
+# deployment.apps "robusta-runner" deleted
+# Error from server (NotFound): deployments.apps "robusta-runner" not found
+
+if [[ $response == *"deleted"* ]]; then
+  echo "Successfully removed robusta-runner deployment from your cluster."
+elif [[ $response == *'Error from server (NotFound): deployments.apps'* ]]; then
+  echo "robusta-runner deployment has already been removed from your cluster."
+else
+  echo "$response"
+  echo "Failed to remove robusta-runner deployment from your cluster. Exiting..."
   exit 1
 fi
 
@@ -121,6 +166,50 @@ else
   exit 1
 fi
 
+response=$(kubectl delete deployment kubecost-cost-analyzer -n kubecost 2>&1)
+# possible responses:
+# deployment.apps "kubecost-cost-analyzer" deleted
+# Error from server (NotFound): deployments.apps "kubecost-cost-analyzer" not found
+
+if [[ $response == *"deleted"* ]]; then
+  echo "Successfully removed kubecost-cost-analyzer deployment from your cluster."
+elif [[ $response == *'Error from server (NotFound): deployments.apps'* ]]; then
+  echo "kubecost-cost-analyzer deployment has already been removed from your cluster."
+else
+  echo "$response"
+  echo "Failed to remove kubecost-cost-analyzer deployment from your cluster. Exiting..."
+  exit 1
+fi
+
+response=$(kubectl delete deployment kubecost-grafana -n kubecost 2>&1)
+# possible responses:
+# deployment.apps "kubecost-grafana" deleted
+# Error from server (NotFound): deployments.apps "kubecost-grafana" not found
+
+if [[ $response == *"deleted"* ]]; then
+  echo "Successfully removed kubecost-grafana deployment from your cluster."
+elif [[ $response == *'Error from server (NotFound): deployments.apps'* ]]; then
+  echo "kubecost-grafana deployment has already been removed from your cluster."
+else
+  echo "$response"
+  echo "Failed to remove kubecost-grafana deployment from your cluster. Exiting..."
+  exit 1
+fi
+response=$(kubectl delete deployment kubecost-kube-state-metrics -n kubecost 2>&1)
+# possible responses:
+# deployment.apps "kubecost-kube-state-metrics" deleted
+# Error from server (NotFound): deployments.apps "kubecost-kube-state-metrics" not found
+
+if [[ $response == *"deleted"* ]]; then
+  echo "Successfully removed kubecost-kube-state-metrics deployment from your cluster."
+elif [[ $response == *'Error from server (NotFound): deployments.apps'* ]]; then
+  echo "kubecost-kube-state-metrics deployment has already been removed from your cluster."
+else
+  echo "$response"
+  echo "Failed to remove kubecost-kube-state-metrics deployment from your cluster. Exiting..."
+  exit 1
+fi
+
 response=$(kubectl delete namespace kubecost 2>&1)
 # possible responses:
 # namespace "kubecost" deleted
@@ -136,18 +225,92 @@ else
   exit 1
 fi
 
-response=$(kubectl delete sa/xkops-secret-sa --namespace xkops 2>&1)
+#https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/describe-stacks.html
+response=$(aws cloudformation describe-stacks --stack-name eksctl-xkops-cluster-addon-iamserviceaccount-xkops-xkops-secret-sa 2>&1)
 # possible responses:
-# serviceaccount "xkops-secret-sa" deleted
-# Error from server (NotFound): serviceaccounts "xkops-secret-sa" not found
+# The output shows the stack information but we only need to check the stack name
+# "StackName": "eksctl-xkops-cluster-addon-iamserviceaccount-xkops-xkops-secret-sa"
+# An error occurred (ValidationError) when calling the DescribeStacks operation: Stack with id eksctl-xkops-cluster-addon-iamserviceaccount-xkops-xkops-secret-sa does not exist
 
-if [[ $response == *"deleted"* ]]; then
-  echo "Successfully deleted xkops-secret-sa service account."
-elif [[ $response == *"Error from server (NotFound)"*  ]]; then
-  echo "xkops-secret-sa service account has already been removed."
+if [[ $response == *'"StackName": "eksctl-xkops-cluster-addon-iamserviceaccount-xkops-xkops-secret-sa"'* ]]; then
+  # Refernce : https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-deleting-stack.html
+  aws cloudformation delete-stack --stack-name eksctl-xkops-cluster-addon-iamserviceaccount-xkops-xkops-secret-sa
+  sleep 3
+  response2=$(aws cloudformation describe-stacks --stack-name eksctl-xkops-cluster-addon-iamserviceaccount-xkops-xkops-secret-sa 2>&1)
+  if [[ $response2 == *"does not exist"* ]]; then
+    echo "Successfully deleted xkops-secret-sa stack."
+  fi
+elif [[ $response == *"does not exist"*  ]]; then
+  echo "xkops-secret-sa stack has already been removed."
 else
   echo "$response"
-  echo "Failed to remove xkops-secret-sa service account. Exiting..."
+  echo "Failed to remove xkops-secret-sa stack. Exiting..."
   exit 1
 fi
+
+# Refernce : https://docs.aws.amazon.com/eks/latest/userguide/managing-add-ons.html
+response=$(eksctl delete addon --cluster xkops-cluster --name aws-ebs-csi-driver 2>&1)
+# possible responses:
+# deleted addon: aws-ebs-csi-driver
+
+if [[ $response == *"deleted addon:"* ]]; then
+  echo "Successfully deleted aws-ebs-csi-driver addon."
+elif [[ $response == *"does not exist"*  ]]; then
+  echo "aws-ebs-csi-driver addon has already been removed."
+else
+  echo "$response"
+  echo "Failed to remove aws-ebs-csi-driver addon. Exiting..."
+  exit 1
+fi
+
+
+# https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/list-attached-role-policies.html
+response=$(aws iam list-attached-role-policies --role-name XkOps-EBS-iam-role 2>&1)
+# possible responses:
+# The response shows the detailes of the policy, we only need the PolicyName to confirm it exists.
+# "PolicyName": "AmazonEBSCSIDriverPolicy"
+# "AttachedPolicies": []
+
+if [[ $response == *'"PolicyName": "AmazonEBSCSIDriverPolicy"'* ]]; then
+  # Refernce : https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/detach-role-policy.html
+  aws iam detach-role-policy --role-name XkOps-EBS-iam-role --policy-arn arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+  response2=$(aws iam list-attached-role-policies --role-name XkOps-EBS-iam-role 2>&1)
+  if [[ $response2 == *'"AttachedPolicies": []'* ]]; then
+    echo "Successfully detached the AmazonEBSCSIDriverPolicy."
+  fi
+elif [[ $response == *'"AttachedPolicies": []'*  ]]; then
+  echo "AmazonEBSCSIDriverPolicy has already been detached."
+else
+  echo "$response"
+  echo "Failed to detach the AmazonEBSCSIDriverPolicy. Exiting..."
+  exit 1
+fi
+
+
+#https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/get-role.html
+response=$(aws iam get-role --role-name XkOps-EBS-iam-role 2>&1)
+# possible responses:
+# The response shows details of the role, we only need the RoleName to confirm it exists.
+# "RoleName": "XkOps-EBS-iam-role"
+# An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name XkOps-EBS-iam-role cannot be found.
+# An error occurred (DeleteConflict) when calling the DeleteRole operation: Cannot delete entity, must detach all policies first.
+
+if [[ $response == *'"RoleName": "XkOps-EBS-iam-role"'* ]]; then
+  # Refernce : https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/delete-role.html
+  aws iam delete-role --role-name XkOps-EBS-iam-role 
+  response2=$(aws iam get-role --role-name XkOps-EBS-iam-role 2>&1)
+  if [[ $response2 == *"cannot be found."* ]]; then
+    echo "Successfully deleted the XkOps-EBS-iam-role."
+  fi
+elif [[ $response == *"cannot be found."*  ]]; then
+  echo "XkOps-EBS-iam-role has already been removed."
+elif [[ $response == *"must detach all policies first."*  ]]; then
+  echo "Error in detaching the policies associated with the role. Cannot delete role without detaching associated policies."
+  exit 1
+else
+  echo "$response"
+  echo "Failed to remove XkOps-EBS-iam-role. Exiting..."
+  exit 1
+fi
+
 


### PR DESCRIPTION
# XkOps

#29 

<!-- Please link the GitHub issues related to this PR, if available -->

## Description
When you uninstall xkops, the following AWS objects were not deleted which caused issues when reinstalling XkOps:
- xkops-secret-sa cloud formation stack.
- Amazon EBS CSI Driver addon
- XkOps-EBS-iam-role 

Fixed this issue to delete these objects and also delete deployments in the namespaces before deleting the namespaces as it was causing issues as namespaces were stuck in terminating state.
 
## Checklist

- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes (if applicable)
- [x] Every function, interface, class has a comment describing what it does and input/output parameters
